### PR TITLE
[Limechain] Create workflow to build docker image and push to dockerhub

### DIFF
--- a/.github/workflows/docker-pipeline.yml
+++ b/.github/workflows/docker-pipeline.yml
@@ -1,0 +1,28 @@
+name: Build and Push Docker Image
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  build-and-push-docker-image:
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'CI:Build')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+
+      - name: Build and push Docker image
+        run: |
+          COMMIT=$(git rev-parse --short HEAD)
+          VERSION=$(git describe --tags --abbrev=0)
+          BUILDNUM=${{ github.run_number }}
+          docker build --build-arg COMMIT=$COMMIT --build-arg VERSION=$VERSION --build-arg BUILDNUM=$BUILDNUM -t ${{ secrets.DOCKER_USERNAME }}/go-ethereum-fork:latest .
+          docker push ${{ secrets.DOCKER_USERNAME }}/go-ethereum-fork:latest


### PR DESCRIPTION
Create workflow triggered upon merging a PR with the `CI:Build` label that does the following:

- Builds a docker image 
- Pushes it to a public dockerhub repo

